### PR TITLE
fix: CHK-3682 update deprecated kotlin gradle configurations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -79,10 +80,9 @@ dependencies {
 
 kotlin { compilerOptions { freeCompilerArgs.addAll("-Xjsr305=strict") } }
 
-tasks.create("applySemanticVersionPlugin") {
-  dependsOn("prepareKotlinBuildScriptModel")
-  apply(plugin = "com.dipien.semantic-version")
-}
+tasks
+  .register("applySemanticVersionPlugin") { dependsOn("prepareKotlinBuildScriptModel") }
+  .apply { apply(plugin = "com.dipien.semantic-version") }
 
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {
   kotlin {
@@ -109,7 +109,7 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
 tasks.register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("auth-v1") {
   generatorName.set("spring")
   inputSpec.set("$rootDir/api-spec/v1/openapi.yaml")
-  outputDir.set("$buildDir/generated")
+  outputDir.set(layout.buildDirectory.get().dir("generated").asFile.toString())
   apiPackage.set("it.pagopa.generated.checkout.authservice.v1.api")
   modelPackage.set("it.pagopa.generated.checkout.authservice.v1.model")
   generateApiDocumentation.set(false)
@@ -139,7 +139,7 @@ tasks.register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("one
   group = "openapi-generation"
   generatorName.set("java")
   inputSpec.set("$rootDir/api-spec/oneidentity/openapi.yaml")
-  outputDir.set("$buildDir/generated")
+  outputDir.set(layout.buildDirectory.get().dir("generated").asFile.toString())
   apiPackage.set("it.pagopa.generated.checkout.oneidentity.api")
   modelPackage.set("it.pagopa.generated.checkout.oneidentity.model")
   generateApiDocumentation.set(false)
@@ -165,7 +165,7 @@ tasks.register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("one
 
 tasks.withType<KotlinCompile> {
   dependsOn("auth-v1", "oneidentity")
-  kotlinOptions.jvmTarget = "21"
+  compilerOptions { jvmTarget.set(JvmTarget.JVM_21) }
 }
 
 tasks.test {


### PR DESCRIPTION
Migration done as per Kotlin Gradle Plugin deprecation warnings

#### List of Changes

- Replace `kotlinOptions.jvmTarget` with modern compilerOptions DSL
- Update `outputDir.set()` to use type-safe layout API
- Follow Gradle's best practices for build configuration
- Improve configuration cache compatibility

#### Motivation and Context

Replaced deprecated Kotlin Gradle configurations with modern type-safe DSL to ensure future compatibility and improve build maintainability.

#### How Has This Been Tested?

relevant tasks executed: `incrementVersion`, `build` and `nativeBuild` locally

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.