### PR TITLE
feat: [CHK-3815] set initial delay for liveness and probeness. set graceful shutdown params

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -11,7 +11,7 @@ microservice-chart:
     httpGet:
       path: /actuator/health/liveness
       port: 8080
-    initialDelaySeconds: 30
+    initialDelaySeconds: 5
     failureThreshold: 6
     periodSeconds: 10
   readinessProbe:
@@ -19,7 +19,7 @@ microservice-chart:
     httpGet:
       path: /actuator/health/readiness
       port: 8080
-    initialDelaySeconds: 30
+    initialDelaySeconds: 5
     failureThreshold: 6
     periodSeconds: 10
   deployment:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -11,7 +11,7 @@ microservice-chart:
     httpGet:
       path: /actuator/health/liveness
       port: 8080
-    initialDelaySeconds: 30
+    initialDelaySeconds: 5
     failureThreshold: 6
     periodSeconds: 10
   readinessProbe:
@@ -19,7 +19,7 @@ microservice-chart:
     httpGet:
       path: /actuator/health/readiness
       port: 8080
-    initialDelaySeconds: 30
+    initialDelaySeconds: 5
     failureThreshold: 6
     periodSeconds: 10
   deployment:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,3 +35,7 @@ oidc.auth-state.cache.ttlSeconds=\${OIDC_AUTH_STATE_CACHE_TTL_SECONDS}
 oidc.keys.cache.ttlSeconds=\${OIDC_KEYS_CACHE_TTL_SECONDS}
 
 session-token.lengthInBytes=\${SESSION_TOKEN_LENGTH_IN_BYTES:16}
+
+# Scaledown / shutdown properties
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=30s


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Setting service configuration for the liveness / readiness probe values and graceful shutdown phase confiuration.

#### List of Changes

- setting liveness / readiness probe initial delay to 5 seconds
- setting graceful shutdown service configuration

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
We identified the need to adjust the configuration for both the liveness/readiness probe initial delay and the shutdown phase values after analyzing the results of different soak test sessions and reviewing service logs.

#### How Has This Been Tested?
tested in soak tests obveserving the autoscaling phases

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.