### PR TITLE
fix: [CHK-3883] delete all keys from Redis command

### DIFF
--- a/src/main/kotlin/it/pagopa/checkout/authservice/repositories/redis/RedisTemplateWrapper.kt
+++ b/src/main/kotlin/it/pagopa/checkout/authservice/repositories/redis/RedisTemplateWrapper.kt
@@ -17,6 +17,8 @@ abstract class RedisTemplateWrapper<V>(
 
     fun delete(key: String): Boolean = redisTemplate.delete("$keyspace:$key")
 
+    fun deleteAll(): Long = redisTemplate.delete(keysInKeyspace())
+
     fun keysInKeyspace(): Set<String> = redisTemplate.keys("$keyspace:*").toSet()
 
     fun getAllValues(): List<V> =

--- a/src/main/kotlin/it/pagopa/checkout/authservice/repositories/redis/RedisTemplateWrapper.kt
+++ b/src/main/kotlin/it/pagopa/checkout/authservice/repositories/redis/RedisTemplateWrapper.kt
@@ -15,7 +15,7 @@ abstract class RedisTemplateWrapper<V>(
 
     fun findById(key: String): V? = redisTemplate.opsForValue()["$keyspace:$key"]
 
-    fun delete(key: String): Boolean = redisTemplate.delete("$keyspace:$key")
+    fun deleteById(key: String): Boolean = redisTemplate.delete("$keyspace:$key")
 
     fun deleteAll(): Long = redisTemplate.delete(keysInKeyspace())
 

--- a/src/main/kotlin/it/pagopa/checkout/authservice/services/AuthenticationService.kt
+++ b/src/main/kotlin/it/pagopa/checkout/authservice/services/AuthenticationService.kt
@@ -125,7 +125,7 @@ class AuthenticationService(
             .doOnNext {
                 logger.info("User logged successfully for state: [{}]", state.value)
                 // user logged in, delete authentication state-nonce from cache
-                oidcAuthStateDataRepository.delete(state.value)
+                oidcAuthStateDataRepository.deleteById(state.value)
             }
     }
 
@@ -165,7 +165,7 @@ class AuthenticationService(
         return sessionTokenUtils
             .getSessionTokenFromRequest(request)
             .flatMap { bearerToken ->
-                Mono.fromCallable { authenticatedUserSessionRepository.delete(bearerToken) }
+                Mono.fromCallable { authenticatedUserSessionRepository.deleteById(bearerToken) }
             }
             .then(Mono.just(Unit))
     }

--- a/src/main/kotlin/it/pagopa/checkout/authservice/utils/JwtUtils.kt
+++ b/src/main/kotlin/it/pagopa/checkout/authservice/utils/JwtUtils.kt
@@ -44,11 +44,15 @@ class JwtUtils(
                     }
                 }
             Mono.firstWithValue(jwtParser).onErrorResume { exception ->
+                logger.error(
+                    "Error performing signature validation for received JWT idToken",
+                    exception,
+                )
                 Mono.fromCallable { oidcKeysRepository.deleteAll() }
                     .doOnNext {
-                        logger.error(
-                            "Cannot validate jwt token with any of the input keys, cleared cached keys: [$it]",
-                            exception,
+                        logger.warn(
+                            "No cached key were valid to validate JWT token, cleared cached keys: [{}]",
+                            it,
                         )
                     }
                     .then(Mono.error(exception))

--- a/src/test/kotlin/it/pagopa/checkout/authservice/repositories/redis/RedisTemplateWrapperTest.kt
+++ b/src/test/kotlin/it/pagopa/checkout/authservice/repositories/redis/RedisTemplateWrapperTest.kt
@@ -61,12 +61,12 @@ class RedisTemplateWrapperTest {
     }
 
     @Test
-    fun `should perform delete operation`() {
+    fun `should perform delete by id operation`() {
         // pre-conditions
         val key = "key"
         given(redisTemplate.delete(any<String>())).willReturn(true)
         // test
-        val returnedValue = mockedRedisTemplate.delete(key)
+        val returnedValue = mockedRedisTemplate.deleteById(key)
         // assertions
         assertEquals(true, returnedValue)
         verify(redisTemplate, times(1)).delete("$keySpace:key")

--- a/src/test/kotlin/it/pagopa/checkout/authservice/repositories/redis/RedisTemplateWrapperTest.kt
+++ b/src/test/kotlin/it/pagopa/checkout/authservice/repositories/redis/RedisTemplateWrapperTest.kt
@@ -73,6 +73,20 @@ class RedisTemplateWrapperTest {
     }
 
     @Test
+    fun `should perform delete all keys operation`() {
+        // pre-conditions
+        val keys = setOf("key1", "key2")
+        given(redisTemplate.keys(any())).willReturn(keys)
+        given(redisTemplate.delete(any<Collection<String>>())).willReturn(keys.size.toLong())
+        // test
+        val returnedValue = mockedRedisTemplate.deleteAll()
+        // assertions
+        assertEquals(2, returnedValue)
+        verify(redisTemplate, times(1)).delete(keys)
+        verify(redisTemplate, times(1)).keys("$keySpace:*")
+    }
+
+    @Test
     fun `should find all keys in keyspace`() {
         // pre-conditions
 

--- a/src/test/kotlin/it/pagopa/checkout/authservice/services/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/checkout/authservice/services/AuthenticationServiceTest.kt
@@ -8,7 +8,8 @@ import it.pagopa.checkout.authservice.exception.SessionValidationException
 import it.pagopa.checkout.authservice.repositories.redis.AuthenticatedUserSessionRepository
 import it.pagopa.checkout.authservice.repositories.redis.OIDCAuthStateDataRepository
 import it.pagopa.checkout.authservice.repositories.redis.bean.auth.*
-import it.pagopa.checkout.authservice.repositories.redis.bean.oidc.*
+import it.pagopa.checkout.authservice.repositories.redis.bean.oidc.AuthCode
+import it.pagopa.checkout.authservice.repositories.redis.bean.oidc.OidcAuthStateData
 import it.pagopa.checkout.authservice.repositories.redis.bean.oidc.OidcNonce
 import it.pagopa.checkout.authservice.repositories.redis.bean.oidc.OidcState
 import it.pagopa.checkout.authservice.utils.JwtUtils
@@ -21,8 +22,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
@@ -208,7 +207,7 @@ class AuthenticationServiceTest {
         given(jwtUtils.validateAndParse(any())).willReturn(Mono.just(jwtResponseClaims))
         given(sessionTokenUtils.generateSessionToken()).willReturn(sessionToken)
         doNothing().`when`(authenticatedUserSessionRepository).save(any())
-        given(oidcAuthStateDataRepository.delete(any())).willReturn(true)
+        given(oidcAuthStateDataRepository.deleteById(any())).willReturn(true)
         // test
         val expectedAuthenticatedUserSession =
             AuthenticatedUserSession(
@@ -231,7 +230,7 @@ class AuthenticationServiceTest {
             .retrieveOidcToken(authCode = authCode, state = oidcState)
         verify(sessionTokenUtils, times(1)).generateSessionToken()
         verify(authenticatedUserSessionRepository, times(1)).save(expectedAuthenticatedUserSession)
-        verify(oidcAuthStateDataRepository, times(1)).delete(oidcState.value)
+        verify(oidcAuthStateDataRepository, times(1)).deleteById(oidcState.value)
     }
 
     @Test
@@ -269,7 +268,7 @@ class AuthenticationServiceTest {
             .willReturn(Mono.just(jwtResponseClaims))
 
         given(sessionTokenUtils.generateSessionToken()).willReturn(sessionToken)
-        given(oidcAuthStateDataRepository.delete(oidcState.value)).willReturn(true)
+        given(oidcAuthStateDataRepository.deleteById(oidcState.value)).willReturn(true)
 
         val expectedAuthenticatedUserSession =
             AuthenticatedUserSession(
@@ -294,7 +293,7 @@ class AuthenticationServiceTest {
             .verify()
 
         verify(oidcAuthStateDataRepository, times(2)).findById(oidcState.value)
-        verify(oidcAuthStateDataRepository, times(1)).delete(oidcState.value)
+        verify(oidcAuthStateDataRepository, times(1)).deleteById(oidcState.value)
         verify(oneIdentityClient, times(1)).retrieveOidcToken(authCode, oidcState)
     }
 
@@ -323,7 +322,7 @@ class AuthenticationServiceTest {
         given(jwtUtils.validateAndParse(any())).willReturn(Mono.just(jwtResponseClaims))
         given(sessionTokenUtils.generateSessionToken()).willReturn(sessionToken)
         doNothing().`when`(authenticatedUserSessionRepository).save(any())
-        given(oidcAuthStateDataRepository.delete(any())).willReturn(true)
+        given(oidcAuthStateDataRepository.deleteById(any())).willReturn(true)
         // test
         val expectedAuthenticatedUserSession =
             AuthenticatedUserSession(
@@ -352,7 +351,7 @@ class AuthenticationServiceTest {
             .retrieveOidcToken(authCode = authCode, state = oidcState)
         verify(sessionTokenUtils, times(0)).generateSessionToken()
         verify(authenticatedUserSessionRepository, times(0)).save(any())
-        verify(oidcAuthStateDataRepository, times(0)).delete(any())
+        verify(oidcAuthStateDataRepository, times(0)).deleteById(any())
     }
 
     @Test
@@ -408,11 +407,11 @@ class AuthenticationServiceTest {
         // test mock
         given { sessionTokenUtils.getSessionTokenFromRequest(request) }
             .willReturn(Mono.just(bearerToken))
-        given { authenticatedUserSessionRepository.delete(bearerToken) }.willReturn(true)
+        given { authenticatedUserSessionRepository.deleteById(bearerToken) }.willReturn(true)
         // test
         StepVerifier.create(authenticationService.logout(request)).expectNext(Unit).verifyComplete()
         verify(sessionTokenUtils, times(1)).getSessionTokenFromRequest(request)
-        verify(authenticatedUserSessionRepository, times(1)).delete(bearerToken)
+        verify(authenticatedUserSessionRepository, times(1)).deleteById(bearerToken)
     }
 
     @Test
@@ -423,11 +422,11 @@ class AuthenticationServiceTest {
         // test mock
         given { sessionTokenUtils.getSessionTokenFromRequest(request) }
             .willReturn(Mono.just(bearerToken))
-        given { authenticatedUserSessionRepository.delete(bearerToken) }.willReturn(false)
+        given { authenticatedUserSessionRepository.deleteById(bearerToken) }.willReturn(false)
         // test
         StepVerifier.create(authenticationService.logout(request)).expectNext(Unit).verifyComplete()
         verify(sessionTokenUtils, times(1)).getSessionTokenFromRequest(request)
-        verify(authenticatedUserSessionRepository, times(1)).delete(bearerToken)
+        verify(authenticatedUserSessionRepository, times(1)).deleteById(bearerToken)
     }
 
     @Test

--- a/src/test/kotlin/it/pagopa/checkout/authservice/utils/JwtUtilsTest.kt
+++ b/src/test/kotlin/it/pagopa/checkout/authservice/utils/JwtUtilsTest.kt
@@ -83,8 +83,7 @@ class JwtUtilsTest {
         verify(oidcKeysRepository, times(1)).getAllValues()
         verify(oneIdentityClient, times(1)).getKeys()
         expectedSavedKeys.forEach { verify(oidcKeysRepository, times(1)).save(it) }
-        verify(oidcKeysRepository, times(0)).keysInKeyspace()
-        verify(oidcKeysRepository, times(0)).delete(any())
+        verify(oidcKeysRepository, times(0)).deleteAll()
     }
 
     @Test
@@ -134,8 +133,7 @@ class JwtUtilsTest {
         verify(oidcKeysRepository, times(1)).getAllValues()
         verify(oneIdentityClient, times(0)).getKeys()
         verify(oidcKeysRepository, times(0)).save(any())
-        verify(oidcKeysRepository, times(0)).keysInKeyspace()
-        verify(oidcKeysRepository, times(0)).delete(any())
+        verify(oidcKeysRepository, times(0)).deleteAll()
     }
 
     @Test
@@ -194,8 +192,7 @@ class JwtUtilsTest {
         verify(oidcKeysRepository, times(1)).getAllValues()
         verify(oneIdentityClient, times(1)).getKeys()
         verify(oidcKeysRepository, times(0)).save(any())
-        verify(oidcKeysRepository, times(0)).keysInKeyspace()
-        verify(oidcKeysRepository, times(0)).delete(any())
+        verify(oidcKeysRepository, times(0)).deleteAll()
     }
 
     @Test
@@ -243,8 +240,7 @@ class JwtUtilsTest {
         verify(oidcKeysRepository, times(1)).getAllValues()
         verify(oneIdentityClient, times(1)).getKeys()
         expectedSavedKeys.forEach { verify(oidcKeysRepository, times(1)).save(it) }
-        verify(oidcKeysRepository, times(0)).keysInKeyspace()
-        verify(oidcKeysRepository, times(0)).delete(any())
+        verify(oidcKeysRepository, times(0)).deleteAll()
     }
 
     @Test
@@ -295,7 +291,7 @@ class JwtUtilsTest {
                 .compact()
         given(oidcKeysRepository.getAllValues()).willReturn(emptyList())
         given(oneIdentityClient.getKeys()).willReturn(Mono.just(oneIdentityResponse))
-        given(oidcKeysRepository.keysInKeyspace()).willReturn(cachedKeys)
+        given(oidcKeysRepository.deleteAll()).willReturn(cachedKeys.size.toLong())
         doNothing().`when`(oidcKeysRepository).save(any())
         Hooks.onOperatorDebug()
         // test
@@ -314,7 +310,6 @@ class JwtUtilsTest {
         verify(oidcKeysRepository, times(1)).getAllValues()
         verify(oneIdentityClient, times(1)).getKeys()
         expectedSavedKeys.forEach { verify(oidcKeysRepository, times(1)).save(it) }
-        verify(oidcKeysRepository, times(1)).keysInKeyspace()
-        cachedKeys.forEach { verify(oidcKeysRepository, times(1)).delete(it) }
+        verify(oidcKeysRepository, times(1)).deleteAll()
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Introduce deleteAll redis template command
refactor delete keys to use Mono.fromCallable construct
<!--- Describe your changes in detail -->

#### Motivation and Context
Delete OIDC keys were not working since delete all operation was performed as delete command called against all keys from keysInKeyspace(). this command return the full key, comprehensive of the keyspace too. 
The delete command already add keyspace resulting in a wrong key to be deleted with keyspace concatenated twice.
In order to avoid future misunderstandings `RedisTemplateWrapper.delete` have been refactored to deleteById
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + local tests with docker 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.